### PR TITLE
.seg loading

### DIFF
--- a/source/util/flat2d.h
+++ b/source/util/flat2d.h
@@ -36,6 +36,7 @@ public:
     unsigned short *m_data_s = nullptr;
 //    unsigned char *m_data_b = nullptr;
     QByteArray m_data_b;
+    QString m_atlas; // Present in .seg only
 
     unsigned int m_width, m_height;
     unsigned char m_bpp;
@@ -43,6 +44,7 @@ public:
     bool m_newFormat = false;
 
     bool Load(QString filename);
+    bool LoadFromSeg(QFile& file);
 
 //    void CreateFake(QString filename, int w, int h,short val);
 


### PR DESCRIPTION
Flat2D::Load automatically calls Flat2D::LoadFromSeg when encountering .seg extension Resulting Flat2D object is compatible with former uses, has an additional m_atlas string member, identifying the atlas.
Caveat/todo: in order to make Nutil actually make use of this change, the various locations looking for the existence of .flat files have to be adjusted too (to accept the availability of .seg files instead).