### PR TITLE
Bugfix: "name\t\colour\n" -> "name\tcolour\n"

### DIFF
--- a/source/ProcessManager/processmanagerpcounter.cpp
+++ b/source/ProcessManager/processmanagerpcounter.cpp
@@ -826,7 +826,7 @@ void ProcessManagerPCounter::SaveCustomReportColors(QSharedPointer<LSheet> sheet
     QString txt ="";
     bool done = false;
     int x = 1;
-    txt+="name\t\colour\n";
+    txt+="name\tcolour\n";
   //  qDebug() << "here";
     while (!done) {
         QString name = sheet->readStr(0,x).trimmed();


### PR DESCRIPTION
Hi, I am trying to compile `nutil` on an Ubuntu box and I am running into a few errors. This first error was easy enough to patch. The combined STDOUT and STDERR log for the unpatched version:
[nutil_make_log_stdout_and_stderr.txt](https://github.com/Neural-Systems-at-UIO/nutil/files/12662190/nutil_make_log_stdout_and_stderr.txt)
